### PR TITLE
Traducciones para verificar el correo

### DIFF
--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -16,5 +16,8 @@
     "Hello!": "¡Hola!",
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser: [:actionURL](:actionURL)": "Si tienes problemas haciendo click en el botón \":actionText\", copia y pega la URL siguiente\nen tu navegador: [:actionURL](:actionURL)",
     "Send Password Reset Link": "Enviar enlace para restablecer contraseña",
-    "Logout": "Cerrar sesión"
+    "Logout": "Cerrar sesión",
+    "Verify Email Address": "Confirmar correo electrónico",
+    "Please click the button below to verify your email address.": "Por favor pulsa el siguiente botón para confirmar tu correo electrónico.",
+    "If you did not create an account, no further action is required.": "Si no creó una cuenta, no es necesario realizar ninguna acción."
 }


### PR DESCRIPTION
Se agrega nuevas traducciones para la nueva funcionalidad de Verificación del correo electrónico incorporadas en la versión 5.7

[más información](https://github.com/laravel/framework/blob/9c844aa37617d8694ba364e16a5f26ecc470c18e/src/Illuminate/Auth/Notifications/VerifyEmail.php#L44)